### PR TITLE
Fix: Proper working directory adress

### DIFF
--- a/lockcell/src/lockcell/constants.py
+++ b/lockcell/src/lockcell/constants.py
@@ -32,7 +32,7 @@ with open(config_path, "r") as f:
 ### Exposing the constants
 
 # USER_SIDE
-USER_WORKING_DIR = _config["paths"]["working_directory"]
+USER_WORKING_DIR = str(Path(_config["paths"]["working_directory"]))
 USER_SCRIPTS_PATH = str(Path(__file__) / "/scripts")
 
 # WORKER_SIDE


### PR DESCRIPTION
The USER_WORKING_DIRECTORY constant format was not well defined sometimes ended with a /, sometimes not, fixed that, now it never ends with /